### PR TITLE
Update formatter function signatures

### DIFF
--- a/flask_admin/_types.py
+++ b/flask_admin/_types.py
@@ -1,6 +1,7 @@
-from typing import Union, Sequence, Dict, Callable
+from typing import Union, Sequence, Dict, Callable, Any
 
 import sqlalchemy
 
 T_COLUMN_LIST = Sequence[Union[str, sqlalchemy.Column]]
-T_FORMATTERS = Dict[type, Callable]  # todo: Make this tighter
+T_FORMATTER = Callable[[Any, Any, Any], Any]
+T_FORMATTERS = Dict[type, T_FORMATTER]

--- a/flask_admin/contrib/geoa/typefmt.py
+++ b/flask_admin/contrib/geoa/typefmt.py
@@ -6,7 +6,7 @@ from geoalchemy2.elements import WKBElement
 from sqlalchemy import func
 
 
-def geom_formatter(view, value, name):
+def geom_formatter(view, value, name) -> str:
     kwargs = {
         "data-role": "leaflet",
         "disabled": "disabled",

--- a/flask_admin/contrib/geoa/typefmt.py
+++ b/flask_admin/contrib/geoa/typefmt.py
@@ -6,7 +6,7 @@ from geoalchemy2.elements import WKBElement
 from sqlalchemy import func
 
 
-def geom_formatter(view, value):
+def geom_formatter(view, value, name):
     kwargs = {
         "data-role": "leaflet",
         "disabled": "disabled",

--- a/flask_admin/contrib/mongoengine/typefmt.py
+++ b/flask_admin/contrib/mongoengine/typefmt.py
@@ -1,3 +1,5 @@
+from typing import Union
+
 from markupsafe import Markup, escape
 
 from mongoengine.base import BaseList
@@ -8,7 +10,7 @@ from flask_admin.model.typefmt import BASE_FORMATTERS, list_formatter
 from . import helpers
 
 
-def grid_formatter(view, value, name):
+def grid_formatter(view, value, name) -> Union[str, Markup]:
     if not value.grid_id:
         return ''
 
@@ -26,7 +28,7 @@ def grid_formatter(view, value, name):
         })
 
 
-def grid_image_formatter(view, value, name):
+def grid_image_formatter(view, value, name) -> Union[str, Markup]:
     if not value.grid_id:
         return ''
 

--- a/flask_admin/contrib/mongoengine/typefmt.py
+++ b/flask_admin/contrib/mongoengine/typefmt.py
@@ -8,7 +8,7 @@ from flask_admin.model.typefmt import BASE_FORMATTERS, list_formatter
 from . import helpers
 
 
-def grid_formatter(view, value):
+def grid_formatter(view, value, name):
     if not value.grid_id:
         return ''
 
@@ -26,7 +26,7 @@ def grid_formatter(view, value):
         })
 
 
-def grid_image_formatter(view, value):
+def grid_image_formatter(view, value, name):
     if not value.grid_id:
         return ''
 

--- a/flask_admin/contrib/sqla/typefmt.py
+++ b/flask_admin/contrib/sqla/typefmt.py
@@ -5,7 +5,7 @@ from flask_admin.model.typefmt import BASE_FORMATTERS, EXPORT_FORMATTERS, \
 from sqlalchemy.orm.collections import InstrumentedList
 
 
-def choice_formatter(view, choice):
+def choice_formatter(view, choice, name):
     """
         Return label of selected choice
         see https://sqlalchemy-utils.readthedocs.io/
@@ -16,7 +16,7 @@ def choice_formatter(view, choice):
     return choice.value
 
 
-def arrow_formatter(view, arrow_time):
+def arrow_formatter(view, arrow_time, name):
     """
         Return human-friendly string of the time relative to now.
         see https://arrow.readthedocs.io/
@@ -27,7 +27,7 @@ def arrow_formatter(view, arrow_time):
     return arrow_time.humanize()
 
 
-def arrow_export_formatter(view, arrow_time):
+def arrow_export_formatter(view, arrow_time, name):
     """
         Return string representation of Arrow object
         see https://arrow.readthedocs.io/

--- a/flask_admin/contrib/sqla/typefmt.py
+++ b/flask_admin/contrib/sqla/typefmt.py
@@ -5,7 +5,7 @@ from flask_admin.model.typefmt import BASE_FORMATTERS, EXPORT_FORMATTERS, \
 from sqlalchemy.orm.collections import InstrumentedList
 
 
-def choice_formatter(view, choice, name):
+def choice_formatter(view, choice, name) -> str:
     """
         Return label of selected choice
         see https://sqlalchemy-utils.readthedocs.io/
@@ -16,7 +16,7 @@ def choice_formatter(view, choice, name):
     return choice.value
 
 
-def arrow_formatter(view, arrow_time, name):
+def arrow_formatter(view, arrow_time, name) -> str:
     """
         Return human-friendly string of the time relative to now.
         see https://arrow.readthedocs.io/
@@ -27,7 +27,7 @@ def arrow_formatter(view, arrow_time, name):
     return arrow_time.humanize()
 
 
-def arrow_export_formatter(view, arrow_time, name):
+def arrow_export_formatter(view, arrow_time, name) -> str:
     """
         Return string representation of Arrow object
         see https://arrow.readthedocs.io/
@@ -47,13 +47,13 @@ DEFAULT_FORMATTERS.update({
 })
 try:
     from sqlalchemy_utils import Choice
-    DEFAULT_FORMATTERS[Choice] = choice_formatter  # type: ignore[assignment]
+    DEFAULT_FORMATTERS[Choice] = choice_formatter
 except ImportError:
     pass
 
 try:
     from arrow import Arrow
-    DEFAULT_FORMATTERS[Arrow] = arrow_formatter  # type: ignore[assignment]
-    EXPORT_FORMATTERS[Arrow] = arrow_export_formatter  # type: ignore[assignment]
+    DEFAULT_FORMATTERS[Arrow] = arrow_formatter
+    EXPORT_FORMATTERS[Arrow] = arrow_export_formatter
 except ImportError:
     pass

--- a/flask_admin/model/typefmt.py
+++ b/flask_admin/model/typefmt.py
@@ -3,6 +3,7 @@ import json
 
 from markupsafe import Markup
 from flask_admin._compat import text_type
+from flask_admin._types import T_FORMATTERS
 
 
 def null_formatter(view, value, name):
@@ -38,7 +39,7 @@ def bool_formatter(view, value, name):
     return Markup('<span class="fa %s glyphicon glyphicon-%s icon-%s" title="%s"></span>' % (fa, glyph, glyph, label))
 
 
-def list_formatter(view, values, name):
+def list_formatter(view, values, name) -> str:
     """
         Return string with comma separated values
 
@@ -48,7 +49,7 @@ def list_formatter(view, values, name):
     return u', '.join(text_type(v) for v in values)
 
 
-def enum_formatter(view, value, name):
+def enum_formatter(view, value, name) -> str:
     """
         Return the name of the enumerated member.
 
@@ -58,7 +59,7 @@ def enum_formatter(view, value, name):
     return value.name
 
 
-def dict_formatter(view, value, name):
+def dict_formatter(view, value, name) -> str:
     """
         Removes unicode entities when displaying dict as string. Also unescapes
         non-ASCII characters stored in the JSON.
@@ -69,20 +70,20 @@ def dict_formatter(view, value, name):
     return json.dumps(value, ensure_ascii=False)
 
 
-BASE_FORMATTERS = {
+BASE_FORMATTERS: T_FORMATTERS = {
     type(None): empty_formatter,
     bool: bool_formatter,
     list: list_formatter,
     dict: dict_formatter,
 }
 
-EXPORT_FORMATTERS = {
+EXPORT_FORMATTERS: T_FORMATTERS = {
     type(None): empty_formatter,
     list: list_formatter,
     dict: dict_formatter,
 }
 
-DETAIL_FORMATTERS = {
+DETAIL_FORMATTERS: T_FORMATTERS = {
     type(None): empty_formatter,
     list: list_formatter,
     dict: dict_formatter,


### PR DESCRIPTION
According to our own warnings, formatter functions should all take three arguments: view, value, and name.

It looks like these formatter functions weren't updated to take the name argument.

<!--
Before opening a PR, open a ticket describing the issue or feature the
PR will address. An issue is not required for fixing typos in
documentation, or other simple non-code changes.

Replace this comment with a description of the change. Describe how it
addresses the linked ticket.
-->

<!--
Link to relevant issues or previous PRs, one per line. Use "fixes" to
automatically close an issue.

fixes #<issue number>
-->

<!--
Ensure each step in the contributing guide is complete, especially the following:

- Add tests that demonstrate the correct behavior of the change. Tests
  should fail without the change.
- Add or update relevant docs, in the docs folder and in code.
- Add an entry in CHANGES.rst summarizing the change and linking to the issue.
- Add `.. versionchanged::` entries in any relevant code docs.
-->
