### PR TITLE
Remove flask-sqlalchemy dependency

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -31,7 +31,6 @@ dependencies = [
 
 [project.optional-dependencies]
 sqlalchemy = [
-    "flask-sqlalchemy>=3",
     "sqlalchemy>=1.4",
 ]
 sqlalchemy-with-utils = [

--- a/requirements/build.txt
+++ b/requirements/build.txt
@@ -14,5 +14,5 @@ pyproject-hooks==1.1.0
     # via build
 tomli==2.0.1
     # via build
-zipp==3.19.2
+zipp==3.20.0
     # via importlib-metadata

--- a/requirements/dev.txt
+++ b/requirements/dev.txt
@@ -21,6 +21,10 @@ beautifulsoup4==4.12.3
     # via
     #   -r tests.in
     #   -r typing.txt
+blinker==1.8.2
+    # via
+    #   -r typing.txt
+    #   flask
 cachetools==5.4.0
     # via tox
 certifi==2024.7.4
@@ -37,6 +41,10 @@ charset-normalizer==3.3.2
     #   -r docs.txt
     #   -r typing.txt
     #   requests
+click==8.1.7
+    # via
+    #   -r typing.txt
+    #   flask
 colorama==0.4.6
     # via tox
 coverage[toml]==7.6.0
@@ -80,6 +88,14 @@ flake8==7.1.0
     #   -r docs.txt
     #   -r tests.in
     #   -r typing.txt
+flask==3.0.3
+    # via
+    #   -r typing.txt
+    #   flask-sqlalchemy
+flask-sqlalchemy==3.1.1
+    # via
+    #   -r tests.in
+    #   -r typing.txt
 identify==2.6.0
     # via pre-commit
 idna==3.7
@@ -94,6 +110,8 @@ imagesize==1.4.1
 importlib-metadata==8.2.0
     # via
     #   -r docs.txt
+    #   -r typing.txt
+    #   flask
     #   sphinx
 iniconfig==2.0.0
     # via
@@ -105,9 +123,15 @@ isort==5.13.2
     #   -r docs.txt
     #   -r typing.txt
     #   pylint
+itsdangerous==2.2.0
+    # via
+    #   -r typing.txt
+    #   flask
 jinja2==3.1.4
     # via
     #   -r docs.txt
+    #   -r typing.txt
+    #   flask
     #   sphinx
 markupsafe==2.1.5
     # via
@@ -115,6 +139,7 @@ markupsafe==2.1.5
     #   -r typing.txt
     #   jinja2
     #   types-wtforms
+    #   werkzeug
 mccabe==0.7.0
     # via
     #   -r docs.txt
@@ -252,6 +277,10 @@ sphinxcontrib-serializinghtml==1.1.5
     # via
     #   -r docs.txt
     #   sphinx
+sqlalchemy==2.0.32
+    # via
+    #   -r typing.txt
+    #   flask-sqlalchemy
 tomli==2.0.1
     # via
     #   -r docs.txt
@@ -316,6 +345,7 @@ typing-extensions==4.12.2
     #   astroid
     #   mypy
     #   pylint
+    #   sqlalchemy
 urllib3==2.2.2
     # via
     #   -r docs.txt
@@ -325,7 +355,12 @@ virtualenv==20.26.3
     # via
     #   pre-commit
     #   tox
-zipp==3.19.2
+werkzeug==3.0.3
+    # via
+    #   -r typing.txt
+    #   flask
+zipp==3.20.0
     # via
     #   -r docs.txt
+    #   -r typing.txt
     #   importlib-metadata

--- a/requirements/docs.txt
+++ b/requirements/docs.txt
@@ -115,5 +115,5 @@ typing-extensions==4.12.2
     #   pylint
 urllib3==2.2.2
     # via requests
-zipp==3.19.2
+zipp==3.20.0
     # via importlib-metadata

--- a/requirements/tests.in
+++ b/requirements/tests.in
@@ -6,3 +6,4 @@ pytest-cov
 
 psycopg2
 beautifulsoup4
+flask-sqlalchemy

--- a/requirements/tests.txt
+++ b/requirements/tests.txt
@@ -8,10 +8,14 @@ astroid==3.2.4
     # via pylint
 beautifulsoup4==4.12.3
     # via -r tests.in
+blinker==1.8.2
+    # via flask
 certifi==2024.7.4
     # via requests
 charset-normalizer==3.3.2
     # via requests
+click==8.1.7
+    # via flask
 coverage[toml]==7.6.0
     # via
     #   coveralls
@@ -26,12 +30,26 @@ exceptiongroup==1.2.2
     # via pytest
 flake8==7.1.0
     # via -r tests.in
+flask==3.0.3
+    # via flask-sqlalchemy
+flask-sqlalchemy==3.1.1
+    # via -r tests.in
 idna==3.7
     # via requests
+importlib-metadata==8.2.0
+    # via flask
 iniconfig==2.0.0
     # via pytest
 isort==5.13.2
     # via pylint
+itsdangerous==2.2.0
+    # via flask
+jinja2==3.1.4
+    # via flask
+markupsafe==2.1.5
+    # via
+    #   jinja2
+    #   werkzeug
 mccabe==0.7.0
     # via
     #   flake8
@@ -60,6 +78,8 @@ requests==2.32.3
     # via coveralls
 soupsieve==2.5
     # via beautifulsoup4
+sqlalchemy==2.0.32
+    # via flask-sqlalchemy
 tomli==2.0.1
     # via
     #   coverage
@@ -71,5 +91,10 @@ typing-extensions==4.12.2
     # via
     #   astroid
     #   pylint
+    #   sqlalchemy
 urllib3==2.2.2
     # via requests
+werkzeug==3.0.3
+    # via flask
+zipp==3.20.0
+    # via importlib-metadata

--- a/requirements/typing.txt
+++ b/requirements/typing.txt
@@ -8,10 +8,14 @@ astroid==3.2.4
     # via pylint
 beautifulsoup4==4.12.3
     # via -r tests.in
+blinker==1.8.2
+    # via flask
 certifi==2024.7.4
     # via requests
 charset-normalizer==3.3.2
     # via requests
+click==8.1.7
+    # via flask
 coverage[toml]==7.6.0
     # via
     #   coveralls
@@ -26,14 +30,27 @@ exceptiongroup==1.2.2
     # via pytest
 flake8==7.1.0
     # via -r tests.in
+flask==3.0.3
+    # via flask-sqlalchemy
+flask-sqlalchemy==3.1.1
+    # via -r tests.in
 idna==3.7
     # via requests
+importlib-metadata==8.2.0
+    # via flask
 iniconfig==2.0.0
     # via pytest
 isort==5.13.2
     # via pylint
+itsdangerous==2.2.0
+    # via flask
+jinja2==3.1.4
+    # via flask
 markupsafe==2.1.5
-    # via types-wtforms
+    # via
+    #   jinja2
+    #   types-wtforms
+    #   werkzeug
 mccabe==0.7.0
     # via
     #   flake8
@@ -73,6 +90,8 @@ requests==2.32.3
     # via coveralls
 soupsieve==2.5
     # via beautifulsoup4
+sqlalchemy==2.0.32
+    # via flask-sqlalchemy
 tomli==2.0.1
     # via
     #   coverage
@@ -114,5 +133,10 @@ typing-extensions==4.12.2
     #   astroid
     #   mypy
     #   pylint
+    #   sqlalchemy
 urllib3==2.2.2
     # via requests
+werkzeug==3.0.3
+    # via flask
+zipp==3.20.0
+    # via importlib-metadata


### PR DESCRIPTION
This is not actually required by flask-admin; our interface is just a SQLAlchemy DB session.

We use `flask-sqlalchemy` in some of our tests, but that's it.

<!--
Before opening a PR, open a ticket describing the issue or feature the
PR will address. An issue is not required for fixing typos in
documentation, or other simple non-code changes.

Replace this comment with a description of the change. Describe how it
addresses the linked ticket.
-->

<!--
Link to relevant issues or previous PRs, one per line. Use "fixes" to
automatically close an issue.

fixes #<issue number>
-->

<!--
Ensure each step in the contributing guide is complete, especially the following:

- Add tests that demonstrate the correct behavior of the change. Tests
  should fail without the change.
- Add or update relevant docs, in the docs folder and in code.
- Add an entry in CHANGES.rst summarizing the change and linking to the issue.
- Add `.. versionchanged::` entries in any relevant code docs.
-->
