### PR TITLE
Add compatibility for wtforms 3.2+

### DIFF
--- a/doc/changelog.rst
+++ b/doc/changelog.rst
@@ -6,6 +6,7 @@ Changelog
 
 Fixes:
 
+* Fixes compatibility with WTForms 3.2+.
 * The `Apply` button for filters will show/hide correctly again
 * Fix `translations_path` attribute when Flask-Admin is used with Flask-Babel
 * Some translation updates.

--- a/flask_admin/_compat.py
+++ b/flask_admin/_compat.py
@@ -39,3 +39,19 @@ def as_unicode(s):
 def csv_encode(s):
     """Returns unicode string expected by Python 3's csv module"""
     return as_unicode(s)
+
+
+def _iter_choices_wtforms_compat(val, label, selected):
+    """Compatibility for 3-tuples and 4-tuples in iter_choices
+
+    https://wtforms.readthedocs.io/en/3.2.x/changes/#version-3-2-0
+    """
+    from packaging.version import Version
+    import wtforms
+
+    wtforms_version = Version(wtforms.__version__)
+
+    if wtforms_version >= Version("3.2.0"):
+        return val, label, selected, {}
+
+    return val, label, selected

--- a/flask_admin/contrib/sqla/fields.py
+++ b/flask_admin/contrib/sqla/fields.py
@@ -10,6 +10,7 @@ from wtforms.fields import StringField
 from wtforms.utils import unset_value
 from wtforms.validators import ValidationError
 
+from flask_admin._compat import _iter_choices_wtforms_compat
 from flask_admin._compat import iteritems
 from flask_admin._compat import string_types
 from flask_admin._compat import text_type
@@ -111,10 +112,14 @@ class QuerySelectField(SelectFieldBase):
 
     def iter_choices(self):
         if self.allow_blank:
-            yield ("__None", self.blank_text, self.data is None)
+            yield _iter_choices_wtforms_compat(
+                "__None", self.blank_text, self.data is None
+            )
 
         for pk, obj in self._get_object_list():
-            yield (pk, self.get_label(obj), obj == self.data)
+            yield _iter_choices_wtforms_compat(
+                pk, self.get_label(obj), obj == self.data
+            )
 
     def process_formdata(self, valuelist):
         if valuelist:
@@ -174,7 +179,9 @@ class QuerySelectMultipleField(QuerySelectField):
 
     def iter_choices(self):
         for pk, obj in self._get_object_list():
-            yield (pk, self.get_label(obj), obj in self.data)
+            yield _iter_choices_wtforms_compat(
+                pk, self.get_label(obj), obj in self.data
+            )
 
     def process_formdata(self, valuelist):
         self._formdata = set(valuelist)

--- a/flask_admin/form/fields.py
+++ b/flask_admin/form/fields.py
@@ -5,6 +5,7 @@ import time
 
 from wtforms import fields
 
+from flask_admin._compat import _iter_choices_wtforms_compat
 from flask_admin._compat import as_unicode
 from flask_admin._compat import text_type
 from flask_admin.babel import gettext
@@ -146,13 +147,17 @@ class Select2Field(fields.SelectField):
 
     def iter_choices(self):
         if self.allow_blank:
-            yield ("__None", self.blank_text, self.data is None)
+            yield _iter_choices_wtforms_compat(
+                "__None", self.blank_text, self.data is None
+            )
 
         for choice in self.choices:
             if isinstance(choice, tuple):
-                yield (choice[0], choice[1], self.coerce(choice[0]) == self.data)
+                yield _iter_choices_wtforms_compat(
+                    choice[0], choice[1], self.coerce(choice[0]) == self.data
+                )
             else:
-                yield (
+                yield _iter_choices_wtforms_compat(
                     choice.value,
                     choice.name,
                     self.coerce(choice.value) == self.data,

--- a/tox.ini
+++ b/tox.ini
@@ -25,11 +25,15 @@ deps =
     -r requirements/tests.txt
 commands_pre =
     noflaskbabel: pip uninstall -y flask-babel
-commands = pytest -v --tb=short --basetemp={envtmpdir} flask_admin/tests {posargs}
+commands =
+    pip freeze
+    pytest -v --tb=short --basetemp={envtmpdir} flask_admin/tests {posargs}
 
 [testenv:py38-min]
 deps = -r requirements-skip/tests-min.txt
-commands = pytest -v --tb=short --basetemp={envtmpdir} flask_admin/tests -W 'default::DeprecationWarning' {posargs}
+commands =
+    pip freeze
+    pytest -v --tb=short --basetemp={envtmpdir} flask_admin/tests -W 'default::DeprecationWarning' {posargs}
 
 [testenv:style]
 deps = pre-commit


### PR DESCRIPTION
https://wtforms.readthedocs.io/en/3.2.x/changes/#version-3-2-0

This version of wtforms has made `iter_choices` expect a 4-tuple rather than a 3-tuple.

This patch adds a compatibility layer to detect and handle that.

<!--
Before opening a PR, open a ticket describing the issue or feature the
PR will address. An issue is not required for fixing typos in
documentation, or other simple non-code changes.

Replace this comment with a description of the change. Describe how it
addresses the linked ticket.
-->

<!--
Link to relevant issues or previous PRs, one per line. Use "fixes" to
automatically close an issue.

fixes #<issue number>
-->

<!--
Ensure each step in the contributing guide is complete, especially the following:

- Add tests that demonstrate the correct behavior of the change. Tests
  should fail without the change.
- Add or update relevant docs, in the docs folder and in code.
- Add an entry in CHANGES.rst summarizing the change and linking to the issue.
- Add `.. versionchanged::` entries in any relevant code docs.
-->
